### PR TITLE
replace obsolete gemc environment with clas12 production

### DIFF
--- a/farm/gemc/goSimulate
+++ b/farm/gemc/goSimulate
@@ -2,8 +2,8 @@
 
 # user setup: environment
 # -----------------------
-source /group/clas12/gemc/environment.csh 4.4.0
-#source /group/clas12/gemc/environment.csh 4.3.2
+source /group/clas12/packages/setup.csh
+module load clas12/pro
 # -----------------
 # end of user setup
 

--- a/farm/gemc/inquireSimulation
+++ b/farm/gemc/inquireSimulation
@@ -10,6 +10,8 @@
 # rootr:   will rootify and remove simulation dir
 # clear:   will remove unfinished directories
 
+source /group/clas12/packages/setup.csh
+module load clas12/pro
 
 set OPT = $1
 

--- a/farm/gemc/rootAdd
+++ b/farm/gemc/rootAdd
@@ -1,7 +1,10 @@
 #!/bin/csh -f
 
+source /group/clas12/packages/setup.csh
+module load clas12/pro
+
 foreach d (`\ls | grep -v added | grep -v rootAdd`)
- hadd $d".root" $d/*.root
+ $ROOTSYS/bin/hadd $d".root" $d/*.root
 end
 
 # creating dir so it's easier to scp


### PR DESCRIPTION
source /group/clas12/gemc/environment.csh 4.4.0 doesn't work anymore.
inevitable to change to clas12/pro.